### PR TITLE
Add third operand 'false' to escape percentage characters

### DIFF
--- a/helpers/ParamConverter.php
+++ b/helpers/ParamConverter.php
@@ -152,6 +152,8 @@ class ParamConverter
                 } elseif ($filter['operator'] == 'endswith') {
                     $value = "%$value";
                 }
+
+		return $value !== null ? [$operator, $attribute, $value, false] : null;
             }
 
             return $value !== null ? [$operator, $attribute, $value] : null;


### PR DESCRIPTION
as stated in http://www.yiiframework.com/doc-2.0/yii-db-queryinterface.html#where()-detail